### PR TITLE
Add user-specific themes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,8 +16,8 @@ import { motion } from 'framer-motion';
 
 // Define the LoginPage functional component
 export default function LoginPage() {
-  // Destructure setUser from the useUser context hook
-  const { setUser } = useUser();
+  // Destructure setUser and setTheme from the useUser context hook
+  const { setUser, setTheme } = useUser();
   // Initialize the router hook
   const router = useRouter();
 
@@ -25,6 +25,8 @@ export default function LoginPage() {
   const handleUserSelect = (user: User) => {
     // Set the selected user in the context
     setUser(user);
+    // Apply the corresponding theme
+    setTheme(user.toLowerCase());
     // Redirect the user to the dashboard page
     router.push('/dashboard');
   };

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -21,13 +21,14 @@ import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 
 
 export function Header() {
-  const { user, setUser } = useUser();
+  const { user, setUser, setTheme } = useUser();
   const router = useRouter();
   const pathname = usePathname();
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const handleLogout = () => {
     setUser(null);
+    setTheme('');
     router.push('/');
   };
 

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -7,6 +7,7 @@ interface UserContextType {
   user: User | null;
   setUser: (user: User | null) => void;
   theme: string;
+  setTheme: (theme: string) => void;
   isLoading: boolean;
 }
 
@@ -14,7 +15,7 @@ export const UserContext = createContext<UserContextType | undefined>(undefined)
 
 export function UserProvider({ children }: { children: ReactNode }) {
   const [user, setUserState] = useState<User | null>(null);
-  const [theme, setTheme] = useState('');
+  const [theme, setThemeState] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -26,9 +27,9 @@ export function UserProvider({ children }: { children: ReactNode }) {
 
       const storedTheme = localStorage.getItem('cozy-theme');
       if (storedTheme) {
-        setTheme(storedTheme);
+        setThemeState(storedTheme);
       } else {
-        setTheme('light'); // Default theme
+        setThemeState(''); // Default no theme
       }
     } catch (e) {
       // localStorage is not available
@@ -46,15 +47,30 @@ export function UserProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (theme) {
       localStorage.setItem('cozy-theme', theme);
+    } else {
+      localStorage.removeItem('cozy-theme');
     }
-  }, [user, isLoading]);
+
+    if (typeof document !== 'undefined') {
+      document.documentElement.classList.remove('theme-tamara', 'theme-carlos');
+      if (theme === 'tamara') {
+        document.documentElement.classList.add('theme-tamara');
+      } else if (theme === 'carlos') {
+        document.documentElement.classList.add('theme-carlos');
+      }
+    }
+  }, [theme]);
 
   const setUser = (newUser: User | null) => {
     setUserState(newUser);
   };
+
+  const setTheme = (newTheme: string) => {
+    setThemeState(newTheme);
+  };
   
   return (
-    <UserContext.Provider value={{ user, setUser, theme, isLoading }}>
+    <UserContext.Provider value={{ user, setUser, theme, setTheme, isLoading }}>
       {children}
     </UserContext.Provider>
   );


### PR DESCRIPTION
## Summary
- manage theme in UserContext and expose setter
- set Tamara or Carlos theme on login
- clear theme when switching user

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685e01d3d6a08325a062204383faed99