### PR TITLE
feat: split profile and configuration settings with theme refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # testing
 /coverage
+dist-test/
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -17,3 +17,24 @@ This is a web application built with Next.js and Firebase that helps users track
 3. Set up a Firebase project and configure the application with your Firebase project details.
 4. Run the development server using `npm run dev`.
 
+## Quickstart actualizado
+
+```bash
+# Instalar dependencias existentes
+npm install
+
+# Variables de entorno
+cp .env.example .env.local
+# Completa las credenciales de Supabase/Firebase antes de levantar el proyecto.
+
+# Linter y typecheck
+npm run lint
+npm run typecheck
+
+# Pruebas automáticas (compila TypeScript a dist-test y ejecuta node --test)
+npm run test
+
+# Levantar entorno local
+npm run dev
+```
+

--- a/docs/adr/2025-10-04-profile-config.md
+++ b/docs/adr/2025-10-04-profile-config.md
@@ -1,0 +1,17 @@
+# ADR 2025-10-04 – Refactor Perfil y Configuración
+
+## Contexto
+El panel de configuración contenía funcionalidades mezcladas, los nombres de temas eran inconsistentes y no existían pruebas automáticas. La restricción del entorno impide instalar nuevas dependencias.
+
+## Decisión
+1. **Tabs Perfil/Configuración**: reorganizar `SettingsPage` usando Radix Tabs para separar edición de perfil de la gestión de parejas.
+2. **Normalización de temas**: introducir `normalizeThemeName` y renombrar a `Blossom`/`Dark` con paletas actualizadas y compatibilidad con alias legados.
+3. **Listados de parejas**: crear `CoupleMembersList` para centralizar la visualización de miembros y estados.
+4. **Pruebas con Node `--test`**: compilar subconjunto TS via `tsconfig.test.json` y ejecutar `node --test` evitando dependencias externas.
+5. **Ícono inline**: reemplazar `lucide-react` por `UsersGlyph` inline para compatibilidad SSR/tests.
+
+## Consecuencias
+- La UI queda modular y responsive, mejorando mantenimiento.
+- Tests pueden ejecutarse en entornos restringidos y documentan los contratos críticos.
+- Al usar imports relativos se facilita la compilación selectiva.
+- Se debe mantener `tsconfig.test.json` en sincronía cuando se agreguen nuevos componentes a probar.

--- a/docs/diagrams/profile-config-c4.md
+++ b/docs/diagrams/profile-config-c4.md
@@ -1,0 +1,30 @@
+# C4 Diagramas – Perfil/Configuración
+
+## C1 – Contexto
+```mermaid
+C4Context
+    title Contexto Cozy Dates
+    Person(user, "Usuario autenticado", "Gestiona su perfil y pareja")
+    System(system, "Cozy Dates", "Aplicación Next.js + Supabase")
+    System_Ext(supabase, "Supabase", "Auth, Storage, Postgres, Edge Functions")
+
+    Rel(user, system, "Actualiza perfil, consulta parejas")
+    Rel(system, supabase, "CRUD profiles/couples, funciones manage-couple")
+```
+
+## C2 – Contenedores
+```mermaid
+C4Container
+    title Contenedores Clave
+    Person(user, "Usuario")
+    Container(app, "Next.js App", "TypeScript/React", "UI, Tabs Perfil/Configuración, Contextos")
+    Container(supabaseDb, "Supabase Postgres", "SQL", "Tablas profiles, profile_couples, couples")
+    Container(supabaseEdge, "Supabase Edge Functions", "TypeScript", "manage-couple, onboarding")
+    Container(storage, "Supabase Storage", "Buckets", "avatars")
+
+    Rel(user, app, "Interacción web")
+    Rel(app, supabaseDb, "Consultas/Mutaciones via supabase-js")
+    Rel(app, storage, "Carga de avatares")
+    Rel(app, supabaseEdge, "Invocar manage-couple")
+    Rel(supabaseEdge, supabaseDb, "Validación y mutaciones seguras")
+```

--- a/docs/profile-config-tech-spec.md
+++ b/docs/profile-config-tech-spec.md
@@ -1,0 +1,60 @@
+# Tech Spec – Perfil y Configuración
+
+## Contexto
+La vista de configuración mezclaba acciones de perfil con la gestión de parejas, usaba nombres de temas obsoletos (Tamara/Carlos) y carecía de pruebas automatizadas. Además, los íconos de avatar se recortaban y no existía documentación operativa para los nuevos flujos.
+
+## Alcance
+- Separar la UI en pestañas **Perfil** y **Configuración**.
+- Normalizar temas a **Blossom** y **Dark** con nuevas paletas.
+- Mostrar miembros de pareja(s) y permitir copiar/invitar con código.
+- Ajustar componente `Avatar` para evitar deformaciones.
+- Agregar pruebas Node `--test` (unitarias + integración renderToStaticMarkup).
+- Añadir documentación auxiliar (README, Runbook, ADR, C4, Tech Spec).
+
+## Arquitectura & Flujos
+- `SettingsPage` (client component) consume `UserContext` y renderiza pestañas usando Radix Tabs.
+- Nueva UI `CoupleMembersList` centraliza la visualización de parejas/miembros.
+- Utilidad `theme.ts` concentra normalización y mapeo de clases, compartida por frontend y tests.
+- Pruebas: `npm run test` compila subconjunto TS (`tsconfig.test.json`) a `dist-test` y ejecuta Node `--test`.
+
+```
+UserContext -> SettingsPage (Tabs) -> Perfil (Formulario + Summary) -> Supabase
+                                   -> Configuración (Invites/Join) -> Edge Function manage-couple
+CoupleMembersList <- members/memberships <- Supabase profile_couples
+```
+
+## Tecnologías
+- Next.js 15 (app router), React 18, Radix UI, Tailwind.
+- Node `--test` + TypeScript compiler para pruebas sin dependencias adicionales.
+- Supabase JS v2 para storage y funciones.
+
+## Contratos & Datos
+- `profiles` tabla: campos usados `id`, `display_name`, `avatar_url`, `theme` (normalizado).
+- `profile_couples` y `couples`: lectura de `status`, `role`, `invite_code`.
+- Edge Function `manage-couple`: recibe `{ action, name?, inviteCode?, user_id }`.
+
+## Seguridad
+- Validación con Zod en formulario de perfil (nombre y tema).
+- Guardas existentes de Supabase (RLS) siguen aplicando; se enfatiza logging de `user_id`.
+- Copia de código usa `navigator.clipboard` con fallback y evita exponer secretos.
+
+## Experiencia de Usuario
+- Perfil: formulario responsive, summary de cuenta y lista de miembros.
+- Configuración: cards independientes para copiar código, crear y unirse.
+- Avatar: `object-cover` + centrado para mantener proporciones.
+
+## Plan de Pruebas
+- `npm run lint`, `npm run typecheck` (manual).
+- `npm run test`: compila tests TS -> JS y ejecuta Node `--test` (unit + integración).
+- Validación manual responsiva en breakpoints móviles/desktop.
+
+## Riesgos y Mitigaciones
+- **Compatibilidad de temas antiguos**: `normalizeThemeName` mantiene alias (`tamara`→`blossom`, `carlos`→`dark`).
+- **Dependencias bloqueadas**: se evitó instalar librerías nuevas usando Node `--test` y wrappers inline.
+- **SSR icons**: se reemplazó dependencia de `lucide-react` por ícono inline.
+
+## Referencias
+- [Next.js App Router Docs](https://nextjs.org/docs)
+- [Supabase JavaScript Client](https://supabase.com/docs/reference/javascript)
+- [Node.js Test Runner](https://nodejs.org/docs/latest/api/test.html)
+- [Radix UI Tabs](https://www.radix-ui.com/primitives/docs/components/tabs)

--- a/docs/runbooks/profile-config-runbook.md
+++ b/docs/runbooks/profile-config-runbook.md
@@ -1,0 +1,30 @@
+# Runbook – Perfil y Configuración
+
+## Objetivo
+Resolver incidencias en la vista de Perfil/Configuración, sincronización de parejas y gestión de temas.
+
+## Checks Rápidos
+1. **Logs de consola**: verificar warnings en `UserContext` y `SettingsPage` (browser + server logs de Supabase).
+2. **Health Supabase**: confirmar disponibilidad de tablas `profiles`, `profile_couples`, función `manage-couple`.
+3. **Storage avatars**: revisar bucket `avatars` cuando el cambio de imagen falle (permisos RLS, tamaño >5MB).
+
+## Troubleshooting
+| Problema | Diagnóstico | Acción |
+| --- | --- | --- |
+| Código de pareja no se copia | `navigator.clipboard` undefined | Se notifica al usuario; sugerir copiar manualmente o revisar permisos HTTPS. |
+| Usuario no ve miembros | Revisar `profile_couples` status (`pending/declined`). | Ejecutar `refreshProfiles()` desde consola o depurar RLS. |
+| Tema incorrecto | Revisar campo `theme` en `profiles`. | Normalizar con `normalizeThemeName` o actualizar en DB (`blossom`/`dark`). |
+
+## Logs útiles
+- `SettingsPage.handleProfileSave`, `SettingsPage.handleJoinCouple` (info/error).
+- `UserContext.loadProfiles` para ver membership y aplicación de temas.
+
+## Métricas y Alertas sugeridas
+- Conteo de errores en función `manage-couple`.
+- Upload failures en bucket `avatars` (> 1/min alerta).
+- Distribución de `theme` para detectar valores legacy.
+
+## Límites conocidos
+- Solo una pareja activa por usuario (UI comunica restricción).
+- Tamaño máximo avatar 5MB (`MAX_AVATAR_MB`).
+- Entorno restringido impide nuevas dependencias; usar pipeline Node `--test`.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "test": "npm run test:compile && npm run test:run",
+    "test:compile": "rm -rf dist-test && tsc -p tsconfig.test.json",
+    "test:run": "node --test dist-test",
     "supabase": "supabase"
   },
   "dependencies": {

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -15,6 +15,9 @@ import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
 import { logError, logInfo } from '@/lib/logger';
+import { AVAILABLE_THEMES } from '@/lib/theme';
+
+const themeOptions = ['default', ...AVAILABLE_THEMES] as const;
 
 const avatarFileSchema = z
   .any()
@@ -44,7 +47,7 @@ const registerSchema = z
     email: z.string().email('Ingresa un correo valido'),
     password: z.string().min(6, 'La contrasena debe tener al menos 6 caracteres'),
     displayName: z.string().min(1, 'Necesitamos un nombre para mostrar'),
-    theme: z.enum(['default', 'tamara', 'carlos']).default('default'),
+    theme: z.enum(themeOptions).default('default'),
     avatarFile: avatarFileSchema,
     hasCoupleCode: z.boolean(),
     coupleCode: z.string().optional(),
@@ -227,8 +230,8 @@ export default function RegisterPage() {
                         </FormControl>
                         <SelectContent>
                           <SelectItem value="default">Automatico</SelectItem>
-                          <SelectItem value="tamara">Tema Tamara</SelectItem>
-                          <SelectItem value="carlos">Tema Carlos</SelectItem>
+                        <SelectItem value="blossom">Tema Blossom</SelectItem>
+                        <SelectItem value="dark">Tema Dark</SelectItem>
                         </SelectContent>
                       </Select>
                       <FormMessage />

--- a/src/app/auth/register/page.tsx.bak
+++ b/src/app/auth/register/page.tsx.bak
@@ -20,7 +20,7 @@ const registerSchema = z
     email: z.string().email('Ingresa un correo valido'),
     password: z.string().min(6, 'La contrasena debe tener al menos 6 caracteres'),
     displayName: z.string().min(1, 'Necesitamos un nombre para mostrar'),
-    theme: z.enum(['default', 'tamara', 'carlos']).default('default'),
+    theme: z.enum(['default', 'blossom', 'dark']).default('default'),
     avatarUrl: z.string().url('La URL debe ser valida').optional().or(z.literal('')),
     mode: z.enum(['create', 'join']).default('create'),
     coupleName: z.string().optional(),
@@ -195,8 +195,8 @@ export default function RegisterPage() {
                         </FormControl>
                         <SelectContent>
                           <SelectItem value="default">Automatico</SelectItem>
-                          <SelectItem value="tamara">Tema Tamara</SelectItem>
-                          <SelectItem value="carlos">Tema Carlos</SelectItem>
+                        <SelectItem value="blossom">Tema Blossom</SelectItem>
+                        <SelectItem value="dark">Tema Dark</SelectItem>
                         </SelectContent>
                       </Select>
                       <FormMessage />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="theme-tamara">
+    <html lang="en" className="theme-blossom">
       <head>
         <link rel="manifest" href="/manifest.json" />
         <meta name="theme-color" content="#d7cce6" />

--- a/src/app/settings/__tests__/profile-schema.test.ts
+++ b/src/app/settings/__tests__/profile-schema.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { profileSchema } from "../profile-schema";
+
+test("profileSchema acepta payloads válidos", () => {
+  const result = profileSchema.safeParse({
+    displayName: "Ana Carolina",
+    theme: "blossom",
+  });
+
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.displayName, "Ana Carolina");
+    assert.equal(result.data.theme, "blossom");
+  }
+});
+
+test("profileSchema normaliza espacios al validar", () => {
+  const result = profileSchema.safeParse({
+    displayName: "   Diego   ",
+    theme: "default",
+  });
+
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.displayName, "Diego");
+  }
+});
+
+test("profileSchema rechaza nombres vacíos", () => {
+  const result = profileSchema.safeParse({
+    displayName: "   ",
+    theme: "dark",
+  });
+
+  assert.equal(result.success, false);
+  if (!result.success) {
+    assert.ok(result.error.issues.some((issue) => issue.message.includes("nombre")));
+  }
+});
+

--- a/src/app/settings/profile-schema.ts
+++ b/src/app/settings/profile-schema.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { AVAILABLE_THEMES, type AppTheme } from "../../lib/theme";
+
+/**
+ * Lista de opciones válidas para el selector de tema en la vista de perfil.
+ * Incluimos "default" como fallback para respetar el auto-theme actual.
+ */
+export const themeOptions = ["default", ...AVAILABLE_THEMES] as const;
+
+export type ThemeOption = (typeof themeOptions)[number];
+
+/**
+ * Schema compartido que valida los campos editables del perfil.
+ * - `displayName` requiere contenido legible (1..80 caracteres).
+ * - `theme` debe pertenecer al catálogo controlado.
+ */
+export const profileSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .min(1, "El nombre no puede estar vacío")
+    .max(80, "Usa un nombre más corto"),
+  theme: z.enum(themeOptions),
+});
+
+/**
+ * Normaliza el valor del selector al tipo persistido en base de datos.
+ * Cuando el usuario elige "default" devolvemos `null` para respetar la lógica automática.
+ */
+export function toPersistedTheme(option: ThemeOption): AppTheme | null {
+  if (option === "default") {
+    return null;
+  }
+
+  return option as AppTheme;
+}

--- a/src/app/watchlist/page.tsx
+++ b/src/app/watchlist/page.tsx
@@ -138,7 +138,6 @@ export default function WatchlistPage() {
                       item={item}
                       onDelete={deleteWatchlistItem}
                       onPlanMovieNight={handlePlanMovieNight}
-                      avatarUrl={user.avatarUrl}
                     />
                   </motion.div>
                 ))}
@@ -187,7 +186,6 @@ export default function WatchlistPage() {
                       item={item}
                       onDelete={deleteWatchlistItem}
                       onPlanMovieNight={handlePlanMovieNight}
-                      avatarUrl={user.avatarUrl}
                     />
                   </motion.div>
                 ))}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -21,19 +21,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { logInfo } from '@/lib/logger';
-
-function getFallbackAvatar(userTheme: string | null): string | undefined {
-  logInfo('getFallbackAvatar', 'getFallbackAvatar', { userTheme });
-  if (userTheme === 'tamara') {
-    return '/img/tamara.png';
-  }
-
-  if (userTheme === 'carlos') {
-    return '/img/carlos.png';
-  }
-
-  return undefined;
-}
+import { getFallbackAvatarForTheme, normalizeThemeName } from '@/lib/theme';
 
 export function Header() {
   const { user, setUser } = useUser();
@@ -49,7 +37,7 @@ export function Header() {
       return user.avatarUrl;
     }
 
-    return getFallbackAvatar(user?.theme ?? null);
+    return getFallbackAvatarForTheme(normalizeThemeName(user?.theme ?? null));
   }, [user]);
 
   const handleLogout = () => {

--- a/src/components/profile/__tests__/couple-members-list.test.tsx
+++ b/src/components/profile/__tests__/couple-members-list.test.tsx
@@ -1,0 +1,68 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CoupleMembersList } from '../couple-members-list';
+import type { CoupleMembership, CoupleSummary, Profile } from '../../../lib/types';
+
+const currentUser: Profile = {
+  id: 'user-1',
+  displayName: 'Alex',
+  avatarUrl: null,
+  theme: 'blossom',
+  coupleId: 'couple-1',
+  confirmedAt: '2024-01-01T00:00:00Z',
+};
+
+const partner: Profile = {
+  id: 'user-2',
+  displayName: 'Sam',
+  avatarUrl: null,
+  theme: 'dark',
+  coupleId: 'couple-1',
+  confirmedAt: '2024-01-01T00:00:00Z',
+};
+
+const pendingMembership: CoupleMembership = {
+  coupleId: 'couple-2',
+  status: 'pending',
+  role: 'member',
+};
+
+const summary: CoupleSummary = {
+  id: 'couple-1',
+  name: 'Team Cozy',
+  inviteCode: 'ABCD1234',
+};
+
+test('CoupleMembersList renders members and highlights the current user', () => {
+  const html = renderToStaticMarkup(
+    <CoupleMembersList
+      currentUserId={currentUser.id}
+      members={[currentUser, partner]}
+      memberships={[pendingMembership]}
+      activeCouple={summary}
+    />,
+  );
+
+  assert.ok(html.includes('Team Cozy'));
+  assert.ok(html.includes('Alex'));
+  assert.ok(html.includes('Sam'));
+  assert.ok(html.includes('Tema Blossom'));
+  assert.ok(html.includes('Tema Dark'));
+  assert.ok(html.includes('Tú'));
+  assert.ok(html.includes('Pendiente'));
+});
+
+test('CoupleMembersList shows helper text when there is no active couple', () => {
+  const html = renderToStaticMarkup(
+    <CoupleMembersList
+      currentUserId={currentUser.id}
+      members={[{ ...currentUser, coupleId: null }]}
+      memberships={[]}
+      activeCouple={null}
+    />,
+  );
+
+  assert.ok(html.includes('Todavía no tienes una pareja aceptada'));
+});

--- a/src/components/profile/couple-members-list.tsx
+++ b/src/components/profile/couple-members-list.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { memo } from 'react';
+
+import type { CoupleMembership, CoupleSummary, Profile } from '../../lib/types';
+import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
+import { Badge } from '../ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
+import { THEME_LABELS } from '../../lib/theme';
+
+/**
+ * Icono inline compatible con SSR/test sin depender de librerías externas.
+ */
+function UsersGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  );
+}
+
+interface CoupleMembersListProps {
+  currentUserId: string;
+  members: Profile[];
+  memberships: CoupleMembership[];
+  activeCouple: CoupleSummary | null;
+}
+
+const STATUS_LABELS: Record<CoupleMembership['status'], string> = {
+  accepted: 'Activa',
+  pending: 'Pendiente',
+  declined: 'Rechazada',
+};
+
+/**
+ * Sección reutilizable que lista las parejas del usuario y sus miembros activos.
+ * Mantener comentarios claros facilita el onboarding de otros devs.
+ */
+function CoupleMembersListComponent({
+  currentUserId,
+  members,
+  memberships,
+  activeCouple,
+}: CoupleMembersListProps) {
+  const acceptedMembers = activeCouple
+    ? members.filter((member) => member.coupleId === activeCouple.id)
+    : [];
+
+  const otherMemberships = memberships.filter((membership) => membership.coupleId !== activeCouple?.id);
+
+  return (
+    <Card className="h-full rounded-3xl border border-border/40 bg-card/80 shadow-lg shadow-primary/5 backdrop-blur">
+      <CardHeader className="flex flex-row items-start justify-between gap-4">
+        <div>
+          <CardTitle>Mis parejas</CardTitle>
+          <CardDescription>
+            Visualiza quién comparte tu cuenta y el estado de cada vínculo.
+          </CardDescription>
+        </div>
+        <UsersGlyph className="h-5 w-5 text-primary" />
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {activeCouple ? (
+          <section aria-label="Pareja activa" className="space-y-3">
+            <div className="flex items-baseline justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">Pareja activa</p>
+                <p className="text-lg font-headline text-foreground">
+                  {activeCouple.name ?? 'Nuestra pareja'}
+                </p>
+              </div>
+              {activeCouple.inviteCode ? (
+                <Badge variant="outline" className="rounded-full border-primary/40 bg-primary/10 text-primary">
+                  Código: {activeCouple.inviteCode}
+                </Badge>
+              ) : null}
+            </div>
+
+            {acceptedMembers.length > 0 ? (
+              <ul className="space-y-3" aria-label="Integrantes de la pareja activa">
+                {acceptedMembers.map((member) => {
+                  const isCurrentUser = member.id === currentUserId;
+                  return (
+                    <li
+                      key={member.id}
+                      className="flex items-center justify-between gap-3 rounded-2xl border border-border/50 bg-muted/40 p-3"
+                    >
+                      <div className="flex items-center gap-3">
+                        <Avatar className="h-11 w-11">
+                          <AvatarImage src={member.avatarUrl ?? undefined} alt={member.displayName} />
+                          <AvatarFallback>{member.displayName.charAt(0).toUpperCase()}</AvatarFallback>
+                        </Avatar>
+                        <div>
+                          <p className="text-sm font-semibold">{member.displayName}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {member.theme ? `Tema ${THEME_LABELS[member.theme]}` : 'Sin tema definido'}
+                          </p>
+                        </div>
+                      </div>
+                      <Badge variant={isCurrentUser ? 'default' : 'secondary'} className="rounded-full px-3 py-1 text-xs">
+                        {isCurrentUser ? 'Tú' : 'Miembro'}
+                      </Badge>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Aún no tienes miembros aceptados dentro de la pareja actual.
+              </p>
+            )}
+          </section>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Todavía no tienes una pareja aceptada. Usa la pestaña de configuración para crear o unirte a una.
+          </p>
+        )}
+
+        {otherMemberships.length > 0 ? (
+          <section aria-label="Otros vínculos" className="space-y-2">
+            <p className="text-sm font-medium text-muted-foreground">Otros estados</p>
+            <ul className="space-y-2">
+              {otherMemberships.map((membership) => (
+                <li
+                  key={`${membership.coupleId}-${membership.status}`}
+                  className="flex items-center justify-between rounded-2xl border border-dashed border-border/60 bg-background/60 p-3 text-sm"
+                >
+                  <span className="font-medium">ID: {membership.coupleId}</span>
+                  <Badge variant="outline" className="rounded-full px-3 py-1 text-xs uppercase tracking-wide">
+                    {STATUS_LABELS[membership.status]}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+export const CoupleMembersList = memo(CoupleMembersListComponent);
+
+CoupleMembersList.displayName = 'CoupleMembersList';
+

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,
@@ -12,7 +12,8 @@ const Avatar = React.forwardRef<
   <AvatarPrimitive.Root
     ref={ref}
     className={cn(
-      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      // Centramos contenido para evitar recortes en diferentes tamaños de imagen.
+      "relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full",
       className
     )}
     {...props}
@@ -26,7 +27,11 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn("aspect-square h-full w-full", className)}
+    className={cn(
+      // object-cover + center garantizan que el rostro permanezca visible sin deformarse.
+      "aspect-square h-full w-full object-cover object-center",
+      className
+    )}
     {...props}
   />
 ))

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/src/lib/__tests__/theme.test.ts
+++ b/src/lib/__tests__/theme.test.ts
@@ -1,0 +1,34 @@
+import {
+  AVAILABLE_THEMES,
+  getFallbackAvatarForTheme,
+  getThemeClassList,
+  normalizeThemeName,
+} from '../theme';
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('theme helpers normalizan nombres legados', () => {
+  assert.equal(normalizeThemeName('tamara'), 'blossom');
+  assert.equal(normalizeThemeName('CARLOS'), 'dark');
+  assert.equal(normalizeThemeName('blossom'), 'blossom');
+});
+
+test('theme helpers devuelven null para valores desconocidos', () => {
+  assert.equal(normalizeThemeName('unknown-theme'), null);
+  assert.equal(normalizeThemeName(''), null);
+});
+
+test('theme helpers generan clases correctas', () => {
+  assert.deepEqual(getThemeClassList('dark'), ['dark', 'theme-dark']);
+  assert.deepEqual(getThemeClassList('blossom'), ['theme-blossom']);
+});
+
+test('theme helpers entregan avatares de respaldo', () => {
+  assert.equal(getFallbackAvatarForTheme('blossom'), '/img/blossom.png');
+  assert.equal(getFallbackAvatarForTheme('dark'), '/img/dark.png');
+});
+
+test('lista de temas disponibles está sincronizada', () => {
+  assert.deepEqual(AVAILABLE_THEMES, ['blossom', 'dark']);
+});

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,18 +1,7 @@
 import type { Profile } from '@/lib/types';
 import { logInfo } from './logger';
 import { supabase } from '@/lib/supabase';
-
-const FALLBACK_AVATARS: Record<string, string> = {
-  blossom: '/img/blossom.png',
-  'theme-blossom': '/img/blossom.png',
-  dark: '/img/dark.png',
-  'theme-dark': '/img/dark.png',
-  // Legacy aliases kept for backwards compatibility
-  tamara: '/img/blossom.png',
-  'theme-tamara': '/img/blossom.png',
-  carlos: '/img/dark.png',
-  'theme-carlos': '/img/dark.png',
-};
+import { getFallbackAvatarForTheme } from '@/lib/theme';
 
 export function getProfileAvatarSrc(profile: Profile | null): string | undefined {
   logInfo('profile', 'getProfileAvatarSrc', profile);
@@ -33,9 +22,8 @@ export function getProfileAvatarSrc(profile: Profile | null): string | undefined
     }
   }
 
-  if (theme && FALLBACK_AVATARS[theme]) {
-    return FALLBACK_AVATARS[theme];
-  }
+  const fallback = getFallbackAvatarForTheme(theme ?? null);
+  if (fallback) return fallback;
 
   return undefined;
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,72 @@
+import { logWarn } from './logger';
+
+/**
+ * Lista de temas disponibles para la experiencia de Cozy Dates.
+ * Mantener sincronizado con la configuración de Tailwind/CSS.
+ */
+export type AppTheme = 'blossom' | 'dark';
+
+const LEGACY_THEME_ALIASES: Record<string, AppTheme> = {
+  blossom: 'blossom',
+  tamara: 'blossom',
+  dark: 'dark',
+  carlos: 'dark',
+};
+
+const THEME_CLASS_REGISTRY: Record<AppTheme, string[]> = {
+  blossom: ['theme-blossom'],
+  dark: ['dark', 'theme-dark'],
+};
+
+/**
+ * Normaliza cualquier valor que venga de Supabase o del cliente para mapearlo a los nombres actuales.
+ * Retorna `null` si el valor no es reconocido.
+ */
+export function normalizeThemeName(rawTheme: string | null | undefined): AppTheme | null {
+  if (!rawTheme) return null;
+  const cleaned = rawTheme.trim().toLowerCase();
+  if (!cleaned) return null;
+
+  const mapped = LEGACY_THEME_ALIASES[cleaned];
+  if (!mapped) {
+    logWarn('theme.normalizeThemeName', 'Tema desconocido, retornamos null', { rawTheme });
+    return null;
+  }
+
+  return mapped;
+}
+
+/**
+ * Determina si un tema requiere las clases de modo oscuro global.
+ */
+export function isDarkTheme(theme: AppTheme | null): boolean {
+  return theme === 'dark';
+}
+
+/**
+ * Obtiene las clases CSS que se deben aplicar al elemento root para un tema dado.
+ */
+export function getThemeClassList(theme: AppTheme | null): string[] {
+  if (!theme) return [];
+  return THEME_CLASS_REGISTRY[theme] ?? [];
+}
+
+/**
+ * Devuelve la ruta del avatar ilustrativo sugerido para cada tema.
+ */
+export function getFallbackAvatarForTheme(theme: AppTheme | null): string | undefined {
+  if (theme === 'blossom') return '/img/blossom.png';
+  if (theme === 'dark') return '/img/dark.png';
+  return undefined;
+}
+
+/**
+ * Permite exponer los nombres válidos para controles de UI (Select, etc.).
+ */
+export const AVAILABLE_THEMES: AppTheme[] = ['blossom', 'dark'];
+
+export const THEME_LABELS: Record<AppTheme, string> = {
+  blossom: 'Blossom',
+  dark: 'Dark',
+};
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,8 +1,10 @@
+import type { AppTheme } from '@/lib/theme';
+
 export interface Profile {
   id: string;
   displayName: string;
   avatarUrl: string | null;
-  theme: string | null;
+  theme: AppTheme | null;
   coupleId: string | null;
   confirmedAt: string | null;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase/functions"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,30 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-test",
+    "module": "commonjs",
+    "target": "ES2019",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"],
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src/lib/theme.ts",
+    "src/app/settings/profile-schema.ts",
+    "src/lib/types.ts",
+    "src/components/profile/couple-members-list.tsx",
+    "src/components/profile/__tests__/**/*.ts",
+    "src/components/profile/__tests__/**/*.tsx",
+    "src/lib/__tests__/**/*.ts",
+    "src/app/settings/__tests__/**/*.ts",
+    "src/components/ui/avatar.tsx",
+    "src/components/ui/card.tsx",
+    "src/components/ui/badge.tsx",
+    "src/lib/utils.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- reorganized the settings experience into dedicated profile/configuration tabs with responsive layout, secure couple management actions, and aligned avatar handling
- introduced shared profile schema helpers with targeted node-based tests alongside couple member UI coverage
- refreshed theme naming/palettes to blossom & dark, updated supporting UI components, docs, and type/test configuration

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0b2194e3083259f3ec75a0c8b8bba