### PR TITLE
feat: refresh account settings experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ npm run test
 npm run dev
 ```
 
+## Configuración de cuenta renovada
+
+- Formularios de perfil con datos personales ampliados (nombre, apellido, apodo, edad y correo editable).
+- Cambio seguro de contraseña directamente desde la pestaña de perfil.
+- Gestión de pareja mediante códigos de invitación compartidos, sin creación duplicada.
+- Nuevo selector de temas con "Automático", "Terracota" y "Dark básico" para personalizar la experiencia visual.
+- Galería fotográfica optimizada con previsualizaciones responsivas, overlay `+N` y visor inmersivo con fondo difuminado.
+

--- a/docs/account-settings-enhancements-tech-spec.md
+++ b/docs/account-settings-enhancements-tech-spec.md
@@ -1,0 +1,51 @@
+# Tech Spec – Renovación de Configuración de Cuenta
+
+## Contexto
+- Consolidar la edición de perfil en Cozy Dates con nuevos campos personales y controles de seguridad.
+- Sustituir la creación de pareja desde el cliente por un flujo único basado en códigos de invitación.
+- Mejorar la experiencia visual de galerías de fotos (tareas y recuerdos) con previsualizaciones responsivas y visor inmersivo.
+- Introducir catálogo de temas actualizado: Automático (default), Terracota y Dark básico.
+
+## Arquitectura y componentes
+- **Next.js (app router, client components)** para la UI (`src/app/settings/page.tsx`).
+- **Contextos React** (`UserContext`) consumen Supabase y exponen datos de perfil extendidos.
+- **Supabase**: Postgres (tabla `profiles` extendida), Edge Function `manage-couple` para vinculación vía código.
+- **PhotoGallery** (`src/components/media/photo-gallery.tsx`) reutiliza Radix Dialog + Embla Carousel para visor reutilizable.
+
+## Tecnologías clave
+- Next.js 15 + React 18.
+- Supabase JS v2 (auth, storage, funciones edge).
+- TailwindCSS + diseño temático CSS custom properties.
+- Radix UI (Dialog, Tabs, Cards) y Embla Carousel para UI accesible.
+
+## Contratos y datos
+- `profiles` añade columnas: `first_name`, `last_name`, `nickname`, `age`, `contact_email`.
+- `profileSchema` (Zod) valida y normaliza payload `{ displayName, firstName, lastName, nickname, age, contactEmail, theme }`.
+- `passwordSchema` (Zod) exige verificación de contraseña actual + nueva (>=12 chars).
+- Edge function `manage-couple` continúa aceptando `action: 'join'` con `inviteCode` y rechaza duplicados vía RLS.
+
+## Seguridad aplicada
+- Validaciones Zod en cliente para inputs nuevos (tipado fuerte y mensajes UX).
+- Reautenticación con `signInWithPassword` antes de `updateUser({ password })` en Supabase.
+- Reversión best-effort de `contact_email` en DB si falla cambio de correo en Auth.
+- Persistencia de temas controlada vía `normalizeThemeName` y clases CSS limitadas.
+- RLS reforzado: `profiles`, `profile_couples`, `couples` habilitados en `supabase/policies.sql`.
+
+## Plan de pruebas
+1. **Unitarias** (`npm run test`):
+   - `theme.test.ts` verifica alias, clases CSS y fallback avatars para nuevos temas.
+   - Nuevos esquemas Zod se ejercitan indirectamente al serializar formulario.
+2. **Manual/UX**:
+   - Guardar perfil con campos válidos e inválidos (ver toasts y mensajes).
+   - Cambiar contraseña con errores (contraseña corta, confirmación distinta, actual incorrecta).
+   - Vinculación de pareja con código válido/erróneo y visualización de estado activo.
+   - Revisión de PhotoGallery en Task/Memories (3 previews, overlay +N, visor responsivo).
+   - Verificar temas: Automático, Terracota, Dark básico (contrastes, modo oscuro y fallback avatars).
+
+## Referencias oficiales
+- [Next.js App Router Docs](https://nextjs.org/docs/app).
+- [Supabase Auth JS v2](https://supabase.com/docs/reference/javascript/auth-updateuser).
+- [Supabase Row Level Security](https://supabase.com/docs/guides/database/postgres/row-level-security).
+- [Radix UI Dialog](https://www.radix-ui.com/primitives/docs/components/dialog).
+- [Embla Carousel React](https://www.embla-carousel.com/docs/react/).
+- [Zod Validation](https://zod.dev/?id=basic-usage).

--- a/docs/adr/2025-03-17-account-settings-ui.md
+++ b/docs/adr/2025-03-17-account-settings-ui.md
@@ -1,0 +1,27 @@
+# ADR 2025-03-17 – Revisión de Configuración de Cuenta y Temas
+
+## Contexto
+- La vista de configuración necesitaba más datos personales (edad, nombre legal, apodo) y gestión segura de credenciales.
+- Existían dos flujos para parejas: crear y unirse; el backend solo garantiza unicidad vía `manage-couple` + RLS.
+- La galería de fotos usaba múltiples implementaciones duplicadas y sin experiencia consistente.
+- El catálogo de temas debía reflejar nueva identidad (Automático, Terracota, Dark básico) reemplazando el antiguo "dark".
+
+## Decisión
+1. **Formulario unificado**: ampliar `profiles` y el UI para capturar datos personales + correo editable; añadir cambio de contraseña con reautenticación.
+2. **Couples solo por código**: eliminar la opción de creación directa desde cliente; mantener `manage-couple` con `action: 'join'` y reforzar mensajes UX.
+3. **PhotoGallery reutilizable**: extraer componente genérico que limita a 3 previews, muestra `+N` y usa Dialog/Carousel con fondo difuminado.
+4. **Temas renombrados**: mapear alias legados a `terracota`, añadir `dark-basic`, `theme-automatic` default y actualizar clases CSS/Tests.
+
+## Consecuencias
+- Nuevas columnas en `profiles` requieren migración (`supabase/migrations/20250317T120000_profile_extended_fields.sql`).
+- UserContext y componentes deben cargar/normalizar campos extra; se actualizan tests de temas.
+- PhotoGallery centraliza la experiencia visual y reduce duplicación; dependencia en Dialog overlay difuminado.
+- Usuarios existentes mantienen compatibilidad gracias a `normalizeThemeName` y alias legados.
+
+## Alternativas consideradas
+- Mantener botón de "crear pareja" y delegar restricción al backend → descartado por UX confuso.
+- Implementar lightbox con librería externa → descartado para evitar dependencias adicionales.
+- Guardar "Automático" como tema persistido → se prefirió mapear a `null` para no romper clientes antiguos.
+
+## Estado
+Aceptado.

--- a/docs/diagrams/account-settings-enhancements-c4.md
+++ b/docs/diagrams/account-settings-enhancements-c4.md
@@ -1,0 +1,32 @@
+# C4 Diagramas – Renovación Configuración de Cuenta
+
+## C1 – Contexto
+```mermaid
+C4Context
+    title Cozy Dates – Cuenta & Galerías
+    Person(usuario, "Usuario autenticado", "Actualiza perfil, vincula pareja y gestiona recuerdos")
+    System(app, "Cozy Dates Web", "Next.js + React")
+    System_Ext(supabase, "Supabase", "Auth, Storage, Postgres, Edge Functions")
+
+    Rel(usuario, app, "Formulario de perfil, temas, PhotoGallery")
+    Rel(app, supabase, "Lectura/actualización profiles, manage-couple, storage de avatares")
+```
+
+## C2 – Contenedores
+```mermaid
+C4Container
+    title Contenedores Clave
+    Person(usuario, "Usuario")
+    Container(web, "Next.js App", "TypeScript/React", "UI de Configuración, PhotoGallery reusable")
+    Container(ctx, "React Contexts", "TypeScript", "UserContext, AuthContext con Supabase")
+    Container(edge, "Supabase Edge Functions", "TypeScript", "manage-couple")
+    Container(db, "Supabase Postgres", "SQL", "Tabla profiles extendida, profile_couples")
+    Container(storage, "Supabase Storage", "Buckets", "avatars, fotos")
+
+    Rel(usuario, web, "Interacción web")
+    Rel(web, ctx, "Leer/actualizar estado de sesión y perfil")
+    Rel(ctx, db, "CRUD profiles/contact_email/age/nickname")
+    Rel(ctx, edge, "Invocar manage-couple (join por código)")
+    Rel(web, storage, "Carga y firma de avatares/fotos")
+    Rel(edge, db, "Validar invitaciones de pareja")
+```

--- a/docs/runbooks/account-settings-enhancements-runbook.md
+++ b/docs/runbooks/account-settings-enhancements-runbook.md
@@ -1,0 +1,39 @@
+# Runbook – Configuración de Cuenta y Galerías
+
+## Objetivo
+Responder rápidamente a incidentes relacionados con edición de perfil, cambio de contraseña, vinculación de pareja y galerías.
+
+## Checklist inicial
+1. **Estado Supabase**
+   - Panel → Health → Postgres/Storage.
+   - Revisión de `profiles`, `profile_couples`, `couples` (latencia, errores 4xx/5xx).
+2. **Logs front-end (Vercel/hosting)**
+   - Buscar `SettingsPage`/`PhotoGallery` en consola para detectar toasts de error recurrentes.
+3. **Edge Functions**
+   - Logs `manage-couple` (Dashboard → Functions → Logs) buscando errores de RLS o códigos inexistentes.
+
+## Troubleshooting
+| Síntoma | Diagnóstico | Acción |
+| --- | --- | --- |
+| Error al guardar perfil / toast rojo | `profiles` sin permisos o validación Zod falló | Verificar payload en consola, revisar RLS (`supabase/policies.sql`). |
+| Cambio de correo no persiste | `updateUser` devuelve error | Confirmar correo válido, revisar logs Supabase Auth. Reintentar; de ser necesario revertir `profiles.contact_email` al valor anterior. |
+| Cambio de contraseña rechaza contraseña actual | `signInWithPassword` falla | Confirmar usuario autenticado (`auth.getUser`). Pedir reautenticación y reintentar. |
+| No se puede vincular pareja | Código inválido o usuario ya vinculado | Revisar logs `manage-couple`, confirmar que `profile_couples` no tenga un `status='accepted'` previo. |
+| Galería no abre visor | Error en PhotoGallery o recursos 404 | Revisar consola y network tab (imagen 404). Confirmar permisos en bucket `avatars`/fotos. |
+
+## Logs clave
+- `SettingsPage.*` (console.info/error) para operaciones de perfil, invitaciones y contraseñas.
+- `manage-couple` (Edge Function) para join codes.
+- `supabase.auth` eventos (Dashboard → Auth → Logs) para cambios de email/password.
+
+## Métricas/Alertas sugeridas
+- Conteo de errores `manage-couple` por código > N en 15min.
+- Tasa de fallos en `updateUser` > 5% (Auth logs).
+- Latencia de `profiles` > 500 ms promedio.
+- SLO UX: menos de 1% de sesiones con toast destructivo en `SettingsPage`.
+
+## Límites conocidos
+- `age` validado entre 0 y 120 (Zod y constraint `smallint`).
+- Supabase Auth exige contraseñas ≥ 12 caracteres tras esta versión.
+- Solo un `profile_couples` con `status='accepted'` por usuario (índice parcial).
+- PhotoGallery muestra máximo 3 miniaturas; resto disponible en visor.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,115 +2,145 @@
 
 @layer base {
   :root {
-    --background: 60 56% 91.2%;
-    --foreground: 300 5% 20%;
+    /* Tema Automático por defecto (cálido + acentos vibrantes) */
+    --background: 18 58% 96%;
+    --foreground: 16 42% 22%;
     --card: 0 0% 100%;
-    --card-foreground: 300 5% 20%;
+    --card-foreground: 16 42% 22%;
     --popover: 0 0% 100%;
-    --popover-foreground: 300 5% 20%;
-    --primary: 300 26.1% 79.8%;
-    --primary-foreground: 300 10% 15%;
-    --secondary: 240 20% 90%;
-    --secondary-foreground: 300 5% 20%;
-    --muted: 240 20% 90%;
-    --muted-foreground: 240 5% 45.1%;
-    --accent: 240 66.7% 94.1%;
-    --accent-foreground: 240 10% 20%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 300 15% 85%;
-    --input: 300 15% 85%;
-    --ring: 300 26.1% 79.8%;
+    --popover-foreground: 16 42% 22%;
+    --primary: 3 76% 64%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 189 48% 90%;
+    --secondary-foreground: 192 40% 28%;
+    --muted: 18 40% 91%;
+    --muted-foreground: 18 28% 45%;
+    --accent: 327 62% 86%;
+    --accent-foreground: 322 46% 32%;
+    --destructive: 352 70% 52%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 18 32% 82%;
+    --input: 18 32% 82%;
+    --ring: 3 76% 64%;
     --radius: 0.8rem;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
+    --chart-1: 3 76% 64%;
+    --chart-2: 189 55% 52%;
+    --chart-3: 327 62% 62%;
+    --chart-4: 45 74% 60%;
+    --chart-5: 208 65% 58%;
     --blossom-color: 335 70% 65%;
-    --dark-color: 150 35% 40%;
+    --terracota-color: 18 60% 48%;
+    --dark-basic-color: 222 45% 32%;
+  }
+
+  .theme-automatic {
+    --background: 18 58% 96%;
+    --foreground: 16 42% 22%;
+    --card: 0 0% 100%;
+    --card-foreground: 16 42% 22%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 16 42% 22%;
+    --primary: 3 76% 64%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 189 48% 90%;
+    --secondary-foreground: 192 40% 28%;
+    --muted: 18 40% 91%;
+    --muted-foreground: 18 28% 45%;
+    --accent: 327 62% 86%;
+    --accent-foreground: 322 46% 32%;
+    --destructive: 352 70% 52%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 18 32% 82%;
+    --input: 18 32% 82%;
+    --ring: 3 76% 64%;
   }
 
   .dark {
-    --background: 240 10% 6%;
+    --background: 222 30% 10%;
     --foreground: 0 0% 98%;
-    --card: 240 10% 8%;
+    --card: 222 28% 13%;
     --card-foreground: 0 0% 98%;
-    --popover: 240 10% 8%;
+    --popover: 222 28% 11%;
     --popover-foreground: 0 0% 98%;
-    --primary: 300 26.1% 79.8%;
-    --primary-foreground: 300 10% 15%;
-    --secondary: 240 3.7% 18%;
+    --primary: 200 80% 60%;
+    --primary-foreground: 210 40% 14%;
+    --secondary: 222 26% 20%;
     --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 18%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 16%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 20%;
-    --input: 240 3.7% 20%;
-    --ring: 300 26.1% 79.8%;
+    --muted: 222 22% 24%;
+    --muted-foreground: 220 14% 70%;
+    --accent: 200 30% 26%;
+    --accent-foreground: 0 0% 92%;
+    --destructive: 352 74% 56%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 222 20% 28%;
+    --input: 222 20% 28%;
+    --ring: 200 80% 60%;
   }
 
   .theme-blossom {
-    /* Soft petal-inspired palette */
     --background: 335 75% 97%;
     --foreground: 340 35% 28%;
-
     --card: 0 0% 100%;
     --card-foreground: 340 35% 28%;
     --popover: 0 0% 100%;
     --popover-foreground: 340 35% 28%;
-
     --primary: 335 70% 64%;
     --primary-foreground: 0 0% 100%;
-
     --secondary: 20 45% 94%;
     --secondary-foreground: 335 30% 30%;
-
     --muted: 330 45% 92%;
     --muted-foreground: 330 30% 45%;
-
     --accent: 265 45% 90%;
     --accent-foreground: 265 35% 32%;
-
     --destructive: 0 68% 60%;
     --destructive-foreground: 0 0% 100%;
-
     --border: 330 35% 82%;
     --input: 330 35% 82%;
     --ring: 335 70% 64%;
   }
 
-  .theme-dark {
-    /* Warm dark theme with coffee notes and forest greens */
-    --background: 26 24% 11%;
-    --foreground: 34 34% 92%;
-
-    --card: 28 22% 14%;
-    --card-foreground: 34 34% 92%;
-    --popover: 26 24% 13%;
-    --popover-foreground: 34 34% 92%;
-
-    --primary: 150 35% 42%;
-    --primary-foreground: 35 30% 94%;
-
-    --secondary: 28 24% 22%;
-    --secondary-foreground: 35 30% 88%;
-
-    --muted: 28 18% 26%;
-    --muted-foreground: 36 20% 70%;
-
-    --accent: 150 28% 24%;
-    --accent-foreground: 120 22% 82%;
-
-    --destructive: 6 64% 48%;
+  .theme-terracota {
+    --background: 24 55% 95%;
+    --foreground: 20 40% 24%;
+    --card: 0 0% 100%;
+    --card-foreground: 20 40% 24%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 20 40% 24%;
+    --primary: 16 72% 56%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 32 45% 88%;
+    --secondary-foreground: 20 38% 28%;
+    --muted: 18 30% 86%;
+    --muted-foreground: 18 28% 42%;
+    --accent: 204 48% 82%;
+    --accent-foreground: 206 42% 28%;
+    --destructive: 352 70% 52%;
     --destructive-foreground: 0 0% 100%;
+    --border: 22 32% 78%;
+    --input: 22 32% 78%;
+    --ring: 16 72% 56%;
+  }
 
-    --border: 28 20% 28%;
-    --input: 28 20% 28%;
-    --ring: 150 35% 42%;
+  .theme-dark-basic {
+    --background: 222 30% 10%;
+    --foreground: 0 0% 96%;
+    --card: 222 28% 14%;
+    --card-foreground: 0 0% 96%;
+    --popover: 222 28% 13%;
+    --popover-foreground: 0 0% 96%;
+    --primary: 200 80% 60%;
+    --primary-foreground: 210 40% 14%;
+    --secondary: 210 24% 18%;
+    --secondary-foreground: 0 0% 96%;
+    --muted: 220 22% 24%;
+    --muted-foreground: 0 0% 82%;
+    --accent: 260 45% 60%;
+    --accent-foreground: 220 30% 16%;
+    --destructive: 352 74% 56%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 222 20% 28%;
+    --input: 222 20% 28%;
+    --ring: 200 80% 60%;
   }
 
   * {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,10 +18,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="theme-blossom">
+    <html lang="en" className="theme-automatic">
       <head>
         <link rel="manifest" href="/manifest.json" />
-        <meta name="theme-color" content="#d7cce6" />
+        <meta name="theme-color" content="#f3777e" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Alegreya:wght@400;700&display=swap" rel="stylesheet" />

--- a/src/app/settings/__tests__/profile-schema.test.ts
+++ b/src/app/settings/__tests__/profile-schema.test.ts
@@ -1,42 +1,72 @@
-import test from "node:test";
-import assert from "node:assert/strict";
+import test from 'node:test';
+import assert from 'node:assert/strict';
 
-import { profileSchema } from "../profile-schema";
+import { passwordSchema, profileSchema } from '../profile-schema';
 
-test("profileSchema acepta payloads válidos", () => {
-  const result = profileSchema.safeParse({
-    displayName: "Ana Carolina",
-    theme: "blossom",
+test('profileSchema normaliza campos opcionales y edad', () => {
+  const parsed = profileSchema.parse({
+    displayName: '  Alex  ',
+    firstName: ' Alex ',
+    lastName: '  Rivera',
+    nickname: ' Lex ',
+    age: '32',
+    contactEmail: '  alex@example.com ',
+    theme: 'default',
   });
 
-  assert.equal(result.success, true);
-  if (result.success) {
-    assert.equal(result.data.displayName, "Ana Carolina");
-    assert.equal(result.data.theme, "blossom");
-  }
+  assert.equal(parsed.displayName, 'Alex');
+  assert.equal(parsed.firstName, 'Alex');
+  assert.equal(parsed.lastName, 'Rivera');
+  assert.equal(parsed.nickname, 'Lex');
+  assert.equal(parsed.age, 32);
+  assert.equal(parsed.contactEmail, 'alex@example.com');
+  assert.equal(parsed.theme, 'default');
 });
 
-test("profileSchema normaliza espacios al validar", () => {
-  const result = profileSchema.safeParse({
-    displayName: "   Diego   ",
-    theme: "default",
+test('profileSchema permite campos opcionales vacíos', () => {
+  const parsed = profileSchema.parse({
+    displayName: 'Alex',
+    firstName: '',
+    lastName: '',
+    nickname: '',
+    age: '',
+    contactEmail: 'alex@example.com',
+    theme: 'terracota',
   });
 
-  assert.equal(result.success, true);
-  if (result.success) {
-    assert.equal(result.data.displayName, "Diego");
-  }
+  assert.equal(parsed.firstName, null);
+  assert.equal(parsed.lastName, null);
+  assert.equal(parsed.nickname, null);
+  assert.equal(parsed.age, null);
 });
 
-test("profileSchema rechaza nombres vacíos", () => {
-  const result = profileSchema.safeParse({
-    displayName: "   ",
-    theme: "dark",
+test('profileSchema rechaza edad inválida', () => {
+  assert.throws(() =>
+    profileSchema.parse({
+      displayName: 'Alex',
+      firstName: '',
+      lastName: '',
+      nickname: '',
+      age: 'abc',
+      contactEmail: 'alex@example.com',
+      theme: 'terracota',
+    }),
+  );
+});
+
+test('passwordSchema valida coincidencia y longitud', () => {
+  const valid = passwordSchema.parse({
+    currentPassword: 'contraseña-actual',
+    newPassword: 'contraseña-nueva-123',
+    confirmPassword: 'contraseña-nueva-123',
   });
+  assert.equal(valid.newPassword, 'contraseña-nueva-123');
 
-  assert.equal(result.success, false);
-  if (!result.success) {
-    assert.ok(result.error.issues.some((issue) => issue.message.includes("nombre")));
-  }
+  assert.throws(() =>
+    passwordSchema.parse({
+      currentPassword: 'actual',
+      newPassword: 'short',
+      confirmPassword: 'different',
+    }),
+  );
 });
-

--- a/src/app/settings/profile-schema.ts
+++ b/src/app/settings/profile-schema.ts
@@ -9,10 +9,30 @@ export const themeOptions = ["default", ...AVAILABLE_THEMES] as const;
 
 export type ThemeOption = (typeof themeOptions)[number];
 
+const optionalNameField = z
+  .string()
+  .trim()
+  .max(80, "Usa un texto más corto")
+  .transform((value) => (value.length === 0 ? null : value));
+
+const ageField = z
+  .preprocess((value) => {
+    if (typeof value === "number") {
+      return Number.isFinite(value) ? Math.trunc(value) : null;
+    }
+
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) return null;
+      const parsed = Number.parseInt(trimmed, 10);
+      return Number.isFinite(parsed) ? parsed : Number.NaN;
+    }
+
+    return null;
+  }, z.number().int().min(0, "La edad debe ser mayor o igual a 0").max(120, "La edad máxima es 120 años").nullable());
+
 /**
  * Schema compartido que valida los campos editables del perfil.
- * - `displayName` requiere contenido legible (1..80 caracteres).
- * - `theme` debe pertenecer al catálogo controlado.
  */
 export const profileSchema = z.object({
   displayName: z
@@ -20,8 +40,53 @@ export const profileSchema = z.object({
     .trim()
     .min(1, "El nombre no puede estar vacío")
     .max(80, "Usa un nombre más corto"),
+  firstName: optionalNameField,
+  lastName: optionalNameField,
+  nickname: optionalNameField,
+  age: ageField,
+  contactEmail: z
+    .string()
+    .trim()
+    .email("Ingresa un correo electrónico válido"),
   theme: z.enum(themeOptions),
 });
+
+export type ProfileFormData = z.infer<typeof profileSchema>;
+
+export const passwordSchema = z
+  .object({
+    currentPassword: z
+      .string()
+      .trim()
+      .min(8, "La contraseña actual debe tener al menos 8 caracteres"),
+    newPassword: z
+      .string()
+      .trim()
+      .min(12, "Usa al menos 12 caracteres en la nueva contraseña"),
+    confirmPassword: z
+      .string()
+      .trim()
+      .min(1, "Confirma la nueva contraseña"),
+  })
+  .superRefine((data, ctx) => {
+    if (data.newPassword !== data.confirmPassword) {
+      ctx.addIssue({
+        path: ["confirmPassword"],
+        code: z.ZodIssueCode.custom,
+        message: "Las contraseñas no coinciden",
+      });
+    }
+
+    if (data.currentPassword === data.newPassword) {
+      ctx.addIssue({
+        path: ["newPassword"],
+        code: z.ZodIssueCode.custom,
+        message: "La nueva contraseña debe ser distinta a la actual",
+      });
+    }
+  });
+
+export type PasswordFormData = z.infer<typeof passwordSchema>;
 
 /**
  * Normaliza el valor del selector al tipo persistido en base de datos.

--- a/src/components/media/photo-gallery.tsx
+++ b/src/components/media/photo-gallery.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import Image from 'next/image';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import {
+  Carousel,
+  CarouselApi,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/components/ui/carousel';
+import { cn } from '@/lib/utils';
+
+interface PhotoGalleryProps {
+  photos: string[];
+  altPrefix: string;
+  emptyState?: ReactNode;
+  previewLimit?: number;
+  className?: string;
+  gridClassName?: string;
+}
+
+export function PhotoGallery({
+  photos,
+  altPrefix,
+  emptyState,
+  previewLimit = 3,
+  className,
+  gridClassName,
+}: PhotoGalleryProps) {
+  const [isLightboxOpen, setLightboxOpen] = useState(false);
+  const [activeSlide, setActiveSlide] = useState(0);
+  const [lightboxApi, setLightboxApi] = useState<CarouselApi | null>(null);
+
+  const previewPhotos = useMemo(() => photos.slice(0, previewLimit), [photos, previewLimit]);
+
+  const openLightboxAt = useCallback((index: number) => {
+    setActiveSlide(index);
+    setLightboxOpen(true);
+  }, []);
+
+  useEffect(() => {
+    if (isLightboxOpen && lightboxApi) {
+      lightboxApi.scrollTo(activeSlide, true);
+    }
+  }, [isLightboxOpen, lightboxApi, activeSlide]);
+
+  useEffect(() => {
+    if (!lightboxApi) return;
+
+    const handleSelect = () => setActiveSlide(lightboxApi.selectedScrollSnap());
+    lightboxApi.on('select', handleSelect);
+    return () => {
+      lightboxApi.off('select', handleSelect);
+    };
+  }, [lightboxApi]);
+
+  if (!photos || photos.length === 0) {
+    return emptyState ? <div className={className}>{emptyState}</div> : null;
+  }
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      <div
+        className={cn(
+          'grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3',
+          gridClassName,
+        )}
+      >
+        {previewPhotos.map((photo, index) => {
+          const isOverflowTile = index === previewPhotos.length - 1 && photos.length > previewLimit;
+          return (
+            <button
+              key={photo}
+              type="button"
+              onClick={() => openLightboxAt(index)}
+              className="group relative h-40 w-full overflow-hidden rounded-2xl border border-border/40 bg-muted/30 transition-transform duration-200 hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <Image
+                src={photo}
+                alt={`${altPrefix} ${index + 1}`}
+                fill
+                className="object-cover"
+                sizes="(min-width: 1280px) 320px, (min-width: 768px) 45vw, 90vw"
+              />
+              <span className="sr-only">Ver {altPrefix.toLowerCase()} {index + 1}</span>
+              {isOverflowTile && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/60 text-lg font-semibold text-white">
+                  +{photos.length - previewLimit}
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <Dialog open={isLightboxOpen} onOpenChange={setLightboxOpen}>
+        <DialogContent className="max-w-5xl w-full border-none bg-background/80 p-6 sm:rounded-3xl shadow-2xl backdrop-blur-xl">
+          <Carousel className="w-full" opts={{ loop: true }} setApi={setLightboxApi}>
+            <CarouselContent className="-ml-0">
+              {photos.map((photo, index) => (
+                <CarouselItem key={`${photo}-modal`} className="flex justify-center">
+                  <div className="relative h-[60vh] w-full max-w-4xl">
+                    <Image
+                      src={photo}
+                      alt={`${altPrefix} ${index + 1}`}
+                      fill
+                      className="object-contain rounded-2xl"
+                      sizes="100vw"
+                    />
+                  </div>
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+            {photos.length > 1 && (
+              <>
+                <CarouselPrevious className="left-6 top-1/2 -translate-y-1/2" />
+                <CarouselNext className="right-6 top-1/2 -translate-y-1/2" />
+              </>
+            )}
+          </Carousel>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/memory-card.tsx
+++ b/src/components/memory-card.tsx
@@ -1,53 +1,24 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 import type { Task } from '@/lib/types';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Carousel, CarouselApi, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
 import { format } from 'date-fns';
 import { CalendarDays, User, Trash2 } from 'lucide-react';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import Image from 'next/image';
-import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Button } from './ui/button';
+import { PhotoGallery } from '@/components/media/photo-gallery';
 import { getProfileAvatarSrc, getProfileDisplayName } from '@/lib/profile';
 
 export function MemoryCard({ task, onDelete }: { task: Task; onDelete: (id: string) => Promise<void> }) {
   const creatorName = getProfileDisplayName(task.createdBy);
   const creatorAvatarUrl = getProfileAvatarSrc(task.createdBy);
   const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [isLightboxOpen, setLightboxOpen] = useState(false);
-  const [activeSlide, setActiveSlide] = useState(0);
-  const [lightboxApi, setLightboxApi] = useState<CarouselApi | null>(null);
-
   const handleConfirmDelete = async () => {
     await onDelete(task.id);
     setDeleteDialogOpen(false);
   };
-
-  const openLightboxAt = useCallback((index: number) => {
-    setActiveSlide(index);
-    setLightboxOpen(true);
-  }, []);
-
-  const previewPhotos = useMemo(() => task.photos.slice(0, 4), [task.photos]);
-
-  useEffect(() => {
-    if (isLightboxOpen && lightboxApi) {
-      lightboxApi.scrollTo(activeSlide, true);
-    }
-  }, [isLightboxOpen, lightboxApi, activeSlide]);
-
-  useEffect(() => {
-    if (!lightboxApi) return;
-
-    const handleSelect = () => setActiveSlide(lightboxApi.selectedScrollSnap());
-    lightboxApi.on('select', handleSelect);
-    return () => {
-      lightboxApi.off('select', handleSelect);
-    };
-  }, [lightboxApi]);
 
   return (
     <Card className="overflow-hidden">
@@ -101,66 +72,11 @@ export function MemoryCard({ task, onDelete }: { task: Task; onDelete: (id: stri
         </div>
       </CardHeader>
       <CardContent>
-        {task.photos && task.photos.length > 0 ? (
-          <>
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-              {previewPhotos.map((photo, index) => {
-                const isOverflowTile = index === previewPhotos.length - 1 && task.photos.length > previewPhotos.length;
-                return (
-                  <button
-                    key={photo}
-                    type="button"
-                    onClick={() => openLightboxAt(index)}
-                    className="group relative h-40 w-full overflow-hidden rounded-2xl border border-border/40 bg-muted/30 transition-transform duration-200 hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    <Image
-                      src={photo}
-                      alt={`Memory photo ${index + 1}`}
-                      fill
-                      className="object-cover"
-                      sizes="(min-width: 1280px) 30vw, (min-width: 768px) 45vw, 90vw"
-                    />
-                    <span className="sr-only">View memory photo {index + 1}</span>
-                    {isOverflowTile && (
-                      <div className="absolute inset-0 flex items-center justify-center bg-black/60 text-lg font-semibold text-white">
-                        +{task.photos.length - previewPhotos.length}
-                      </div>
-                    )}
-                  </button>
-                );
-              })}
-            </div>
-            <Dialog open={isLightboxOpen} onOpenChange={setLightboxOpen}>
-              <DialogContent className="max-w-4xl w-full border-none bg-background/95 p-6 sm:rounded-3xl shadow-2xl">
-                <Carousel className="w-full" opts={{ loop: true }} setApi={setLightboxApi}>
-                  <CarouselContent className="-ml-0">
-                    {task.photos.map((photo, index) => (
-                      <CarouselItem key={`${photo}-modal`} className="flex justify-center">
-                        <div className="relative h-[60vh] w-full max-w-3xl">
-                          <Image
-                            src={photo}
-                            alt={`Memory photo ${index + 1}`}
-                            fill
-                            className="object-contain rounded-2xl"
-                            sizes="100vw"
-                          />
-                        </div>
-                      </CarouselItem>
-                    ))}
-                  </CarouselContent>
-                  {task.photos.length > 1 && (
-                    <>
-                      <CarouselPrevious className="left-6 top-1/2 -translate-y-1/2" />
-                      <CarouselNext className="right-6 top-1/2 -translate-y-1/2" />
-                    </>
-                  )}
-                </Carousel>
-              </DialogContent>
-            </Dialog>
-          </>
-        ) : (
-          <p className="text-sm text-muted-foreground">No photos for this memory yet.</p>
-        )}
+        <PhotoGallery
+          photos={task.photos}
+          altPrefix="Foto del recuerdo"
+          emptyState={<p className="text-sm text-muted-foreground">No photos for this memory yet.</p>}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/profile/__tests__/couple-members-list.test.tsx
+++ b/src/components/profile/__tests__/couple-members-list.test.tsx
@@ -8,6 +8,12 @@ import type { CoupleMembership, CoupleSummary, Profile } from '../../../lib/type
 const currentUser: Profile = {
   id: 'user-1',
   displayName: 'Alex',
+  firstName: 'Alex',
+  lastName: 'Rivera',
+  nickname: 'Lex',
+  age: 29,
+  contactEmail: 'alex@example.com',
+  accountEmail: 'alex@example.com',
   avatarUrl: null,
   theme: 'blossom',
   coupleId: 'couple-1',
@@ -17,8 +23,14 @@ const currentUser: Profile = {
 const partner: Profile = {
   id: 'user-2',
   displayName: 'Sam',
+  firstName: 'Sam',
+  lastName: 'Lopez',
+  nickname: null,
+  age: 30,
+  contactEmail: 'sam@example.com',
+  accountEmail: 'sam@example.com',
   avatarUrl: null,
-  theme: 'dark',
+  theme: 'terracota',
   coupleId: 'couple-1',
   confirmedAt: '2024-01-01T00:00:00Z',
 };
@@ -49,7 +61,7 @@ test('CoupleMembersList renders members and highlights the current user', () => 
   assert.ok(html.includes('Alex'));
   assert.ok(html.includes('Sam'));
   assert.ok(html.includes('Tema Blossom'));
-  assert.ok(html.includes('Tema Dark'));
+  assert.ok(html.includes('Tema Terracota'));
   assert.ok(html.includes('Tú'));
   assert.ok(html.includes('Pendiente'));
 });

--- a/src/components/task-card.tsx
+++ b/src/components/task-card.tsx
@@ -10,9 +10,9 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { CalendarDays, Tag, Flag, Trash2, User, Camera } from 'lucide-react';
 import { format } from 'date-fns';
-import Image from 'next/image';
 import { useToast } from '@/hooks/use-toast';
 import { getProfileAvatarSrc, getProfileDisplayName } from '@/lib/profile';
+import { PhotoGallery } from '@/components/media/photo-gallery';
 
 interface TaskCardProps {
   task: Task;
@@ -161,24 +161,12 @@ export function TaskCard({ task, onToggleComplete, onDelete, onAddPhoto }: TaskC
               </div>
             </div>
             {task.photos && task.photos.length > 0 ? (
-              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
-                {task.photos.slice(0, 4).map((photo, index) => (
-                  <div key={photo} className="relative aspect-square">
-                    <Image
-                      src={photo}
-                      alt={`Memory ${index + 1}`}
-                      width={100}
-                      height={100}
-                      className="rounded-md object-cover w-full h-full"
-                    />
-                    {index === 3 && task.photos.length > 4 && (
-                      <div className="absolute inset-0 bg-black/50 flex items-center justify-center rounded-md">
-                        <span className="text-white font-bold text-lg">+{task.photos.length - 4}</span>
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
+              <PhotoGallery
+                photos={task.photos}
+                altPrefix="Recuerdo de la tarea"
+                previewLimit={3}
+                gridClassName="grid-cols-2 sm:grid-cols-3"
+              />
             ) : (
               <p className="text-xs text-muted-foreground">No photos added yet.</p>
             )}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/70 backdrop-blur-md supports-[backdrop-filter]:backdrop-blur-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/lib/__tests__/theme.test.ts
+++ b/src/lib/__tests__/theme.test.ts
@@ -10,7 +10,9 @@ import assert from 'node:assert/strict';
 
 test('theme helpers normalizan nombres legados', () => {
   assert.equal(normalizeThemeName('tamara'), 'blossom');
-  assert.equal(normalizeThemeName('CARLOS'), 'dark');
+  assert.equal(normalizeThemeName('CARLOS'), 'terracota');
+  assert.equal(normalizeThemeName('dark-basic'), 'dark-basic');
+  assert.equal(normalizeThemeName('automatic'), null);
   assert.equal(normalizeThemeName('blossom'), 'blossom');
 });
 
@@ -20,15 +22,17 @@ test('theme helpers devuelven null para valores desconocidos', () => {
 });
 
 test('theme helpers generan clases correctas', () => {
-  assert.deepEqual(getThemeClassList('dark'), ['dark', 'theme-dark']);
+  assert.deepEqual(getThemeClassList('dark-basic'), ['dark', 'theme-dark-basic']);
   assert.deepEqual(getThemeClassList('blossom'), ['theme-blossom']);
+  assert.deepEqual(getThemeClassList('terracota'), ['theme-terracota']);
 });
 
 test('theme helpers entregan avatares de respaldo', () => {
   assert.equal(getFallbackAvatarForTheme('blossom'), '/img/blossom.png');
-  assert.equal(getFallbackAvatarForTheme('dark'), '/img/dark.png');
+  assert.equal(getFallbackAvatarForTheme('terracota'), '/img/carlos.png');
+  assert.equal(getFallbackAvatarForTheme('dark-basic'), '/img/dark.png');
 });
 
 test('lista de temas disponibles está sincronizada', () => {
-  assert.deepEqual(AVAILABLE_THEMES, ['blossom', 'dark']);
+  assert.deepEqual(AVAILABLE_THEMES, ['blossom', 'terracota', 'dark-basic']);
 });

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -29,5 +29,14 @@ export function getProfileAvatarSrc(profile: Profile | null): string | undefined
 }
 
 export function getProfileDisplayName(profile: Profile | null): string {
-  return profile?.displayName ?? 'Unknown';
+  if (!profile) return 'Unknown';
+
+  const candidates = [profile.nickname, profile.firstName, profile.displayName];
+  for (const candidate of candidates) {
+    if (candidate && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+
+  return 'Unknown';
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -4,18 +4,27 @@ import { logWarn } from './logger';
  * Lista de temas disponibles para la experiencia de Cozy Dates.
  * Mantener sincronizado con la configuración de Tailwind/CSS.
  */
-export type AppTheme = 'blossom' | 'dark';
+export type AppTheme = 'blossom' | 'terracota' | 'dark-basic';
 
 const LEGACY_THEME_ALIASES: Record<string, AppTheme> = {
   blossom: 'blossom',
   tamara: 'blossom',
-  dark: 'dark',
-  carlos: 'dark',
+  'theme-blossom': 'blossom',
+  dark: 'terracota',
+  terracota: 'terracota',
+  terracotta: 'terracota',
+  carlos: 'terracota',
+  'theme-dark': 'terracota',
+  'theme-terracota': 'terracota',
+  'dark-basic': 'dark-basic',
+  darkbasic: 'dark-basic',
+  'theme-dark-basic': 'dark-basic',
 };
 
 const THEME_CLASS_REGISTRY: Record<AppTheme, string[]> = {
   blossom: ['theme-blossom'],
-  dark: ['dark', 'theme-dark'],
+  terracota: ['theme-terracota'],
+  'dark-basic': ['dark', 'theme-dark-basic'],
 };
 
 /**
@@ -26,6 +35,10 @@ export function normalizeThemeName(rawTheme: string | null | undefined): AppThem
   if (!rawTheme) return null;
   const cleaned = rawTheme.trim().toLowerCase();
   if (!cleaned) return null;
+
+  if (cleaned === 'automatic' || cleaned === 'default') {
+    return null;
+  }
 
   const mapped = LEGACY_THEME_ALIASES[cleaned];
   if (!mapped) {
@@ -40,7 +53,7 @@ export function normalizeThemeName(rawTheme: string | null | undefined): AppThem
  * Determina si un tema requiere las clases de modo oscuro global.
  */
 export function isDarkTheme(theme: AppTheme | null): boolean {
-  return theme === 'dark';
+  return theme === 'dark-basic';
 }
 
 /**
@@ -56,17 +69,19 @@ export function getThemeClassList(theme: AppTheme | null): string[] {
  */
 export function getFallbackAvatarForTheme(theme: AppTheme | null): string | undefined {
   if (theme === 'blossom') return '/img/blossom.png';
-  if (theme === 'dark') return '/img/dark.png';
+  if (theme === 'terracota') return '/img/carlos.png';
+  if (theme === 'dark-basic') return '/img/dark.png';
   return undefined;
 }
 
 /**
  * Permite exponer los nombres válidos para controles de UI (Select, etc.).
  */
-export const AVAILABLE_THEMES: AppTheme[] = ['blossom', 'dark'];
+export const AVAILABLE_THEMES: AppTheme[] = ['blossom', 'terracota', 'dark-basic'];
 
 export const THEME_LABELS: Record<AppTheme, string> = {
   blossom: 'Blossom',
-  dark: 'Dark',
+  terracota: 'Terracota',
+  'dark-basic': 'Dark básico',
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,12 @@ import type { AppTheme } from '@/lib/theme';
 export interface Profile {
   id: string;
   displayName: string;
+  firstName: string | null;
+  lastName: string | null;
+  nickname: string | null;
+  age: number | null;
+  contactEmail: string | null;
+  accountEmail: string | null;
   avatarUrl: string | null;
   theme: AppTheme | null;
   coupleId: string | null;

--- a/supabase/migrations/20250317T120000_profile_extended_fields.sql
+++ b/supabase/migrations/20250317T120000_profile_extended_fields.sql
@@ -1,0 +1,21 @@
+-- Extiende el perfil con datos adicionales requeridos por la nueva UI.
+alter table public.profiles
+  add column if not exists first_name text;
+
+alter table public.profiles
+  add column if not exists last_name text;
+
+alter table public.profiles
+  add column if not exists nickname text;
+
+alter table public.profiles
+  add column if not exists age smallint check (age >= 0 and age <= 120);
+
+alter table public.profiles
+  add column if not exists contact_email text;
+
+comment on column public.profiles.first_name is 'Nombre legal utilizado para personalizar la experiencia.';
+comment on column public.profiles.last_name is 'Apellido legal utilizado para personalizar la experiencia.';
+comment on column public.profiles.nickname is 'Apodo opcional mostrado en la UI.';
+comment on column public.profiles.age is 'Edad aproximada para personalizar recomendaciones.';
+comment on column public.profiles.contact_email is 'Correo de contacto preferido para notificaciones fuera de banda.';

--- a/supabase/policies.sql
+++ b/supabase/policies.sql
@@ -1,0 +1,95 @@
+-- Políticas RLS necesarias para la configuración de cuenta.
+
+alter table public.profiles enable row level security;
+alter table public.profile_couples enable row level security;
+alter table public.couples enable row level security;
+
+do
+$$
+begin
+  if not exists (
+    select 1
+      from pg_policies
+     where schemaname = 'public'
+       and tablename = 'profiles'
+       and policyname = 'Users can view their profiles'
+  ) then
+    execute 'create policy "Users can view their profiles" on public.profiles for select using (auth.uid() = id)';
+  end if;
+end;
+$$;
+
+do
+$$
+begin
+  if not exists (
+    select 1
+      from pg_policies
+     where schemaname = 'public'
+       and tablename = 'profiles'
+       and policyname = 'Users can update their own profiles'
+  ) then
+    execute 'create policy "Users can update their own profiles" on public.profiles for update using (auth.uid() = id) with check (auth.uid() = id)';
+  end if;
+end;
+$$;
+
+do
+$$
+begin
+  if not exists (
+    select 1
+      from pg_policies
+     where schemaname = 'public'
+       and tablename = 'profile_couples'
+       and policyname = 'Users can view their memberships'
+  ) then
+    execute 'create policy "Users can view their memberships" on public.profile_couples for select using (auth.uid() = profile_id)';
+  end if;
+end;
+$$;
+
+do
+$$
+begin
+  if not exists (
+    select 1
+      from pg_policies
+     where schemaname = 'public'
+       and tablename = 'profile_couples'
+       and policyname = 'Users manage their memberships'
+  ) then
+    execute 'create policy "Users manage their memberships" on public.profile_couples for insert with check (auth.uid() = profile_id)';
+  end if;
+end;
+$$;
+
+do
+$$
+begin
+  if not exists (
+    select 1
+      from pg_policies
+     where schemaname = 'public'
+       and tablename = 'profile_couples'
+       and policyname = 'Users manage their memberships updates'
+  ) then
+    execute 'create policy "Users manage their memberships updates" on public.profile_couples for update using (auth.uid() = profile_id) with check (auth.uid() = profile_id)';
+  end if;
+end;
+$$;
+
+do
+$$
+begin
+  if not exists (
+    select 1
+      from pg_policies
+     where schemaname = 'public'
+       and tablename = 'couples'
+       and policyname = 'Users can read couples for accepted membership'
+  ) then
+    execute 'create policy "Users can read couples for accepted membership" on public.couples for select using (exists (select 1 from public.profile_couples pc where pc.couple_id = couples.id and pc.profile_id = auth.uid() and pc.status = ''accepted''))';
+  end if;
+end;
+$$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,36 @@
+-- Esquema relevante para la configuración de cuenta y parejas.
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  display_name text not null,
+  avatar_url text,
+  theme text,
+  confirmed_at timestamptz,
+  first_name text,
+  last_name text,
+  nickname text,
+  age smallint check (age >= 0 and age <= 120),
+  contact_email text,
+  created_at timestamptz default timezone('utc', now()),
+  updated_at timestamptz default timezone('utc', now())
+);
+
+create table if not exists public.couples (
+  id uuid primary key default gen_random_uuid(),
+  name text,
+  invite_code text unique,
+  created_at timestamptz default timezone('utc', now())
+);
+
+create table if not exists public.profile_couples (
+  profile_id uuid references public.profiles(id) on delete cascade,
+  couple_id uuid references public.couples(id) on delete cascade,
+  status text not null check (status in ('pending', 'accepted', 'declined')),
+  role text not null check (role in ('owner', 'member')),
+  created_at timestamptz default timezone('utc', now()),
+  updated_at timestamptz default timezone('utc', now()),
+  primary key (profile_id, couple_id)
+);
+
+create unique index if not exists profile_couples_single_accepted_idx
+  on public.profile_couples(profile_id)
+  where status = 'accepted';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -66,7 +66,8 @@ export default {
           ring: 'hsl(var(--sidebar-ring))',
         },
         blossom: 'hsl(var(--blossom-color))',
-        dark: 'hsl(var(--dark-color))',
+        terracota: 'hsl(var(--terracota-color))',
+        'dark-basic': 'hsl(var(--dark-basic-color))',
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## Summary
- expand the account settings page with richer profile fields, password change, and join-by-code couple management
- add a reusable photo gallery with limited previews and immersive lightbox for tasks and memories
- rename the dark theme to terracota, introduce new theme tokens, docs, and Supabase schema updates

## Testing
- npm run lint
- npm run typecheck
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e14c9ad0fc832595521602342bde11